### PR TITLE
[WIP] ci: Add weekly test workflow file

### DIFF
--- a/.github/workflows/weekly_tests.yaml
+++ b/.github/workflows/weekly_tests.yaml
@@ -1,0 +1,23 @@
+name: Weekly Tests
+
+on:
+  schedule:
+    - cron: "0 0 * * SAT"
+
+jobs:
+  run-tests:
+    uses: ./.github/workflows/check.yaml
+
+  notify-on-failure:
+    needs: run-tests
+    if: ${{ failure() }}
+    name: Notify Mattermost Channel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create the Mattermost Message
+        run: |
+          echo "{\"text\":\":robot_face: Weekly test has failed for project \`${{ github.repository }}\`\"}" > mattermost.json
+
+      - uses: mattermost/action-mattermost-notify@master
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}

--- a/tests/functional/tests/modules/utils.py
+++ b/tests/functional/tests/modules/utils.py
@@ -1,4 +1,5 @@
 """Utilities to be used during charm-local-users functests."""
+
 import logging
 
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/tests/functional/tests/test_local_users.py
+++ b/tests/functional/tests/test_local_users.py
@@ -1,4 +1,5 @@
 """Functional tests for charm-local-users."""
+
 from subprocess import run
 from time import sleep
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
Runs lint, unit and functional tests at specified time weekly. If the test fails, the pre-configured Mattermost channel is notified with a message. 

In order to understand the changes better, take a look at the runs in ["Weekly Tests" action ](https://github.com/dashmage/charm-local-users/actions/workflows/weekly_tests.yaml) in the `dashmage/charm-local-users` project. 

[Run with test passing](https://github.com/dashmage/charm-local-users/actions/runs/7744421268)
[Run with test failing and Mattermost channel being notified](https://github.com/dashmage/charm-local-users/actions/runs/7744615965)

The above POC was configured with a webhook from my Mattermost user which would create a message like this:
![image](https://github.com/canonical/charm-local-users/assets/25390807/3c49d789-4e42-489a-b483-7bc37afc6e89)

Helpful references:
- [failure() status check function](https://docs.github.com/en/actions/learn-github-actions/expressions#failure)
- [Mattermost notify action](https://github.com/mattermost/action-mattermost-notify/)
- [schedule event to trigger workflow](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)

Note: Status is WIP because we are still waiting for the Mattermost bot account through which we can create the webhook and add the `MATTERMOST_WEBHOOK_URL` secret`. 