### PR TITLE
ci: Add arm64 runner to ci

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -26,14 +26,21 @@ jobs:
       tox-version: "<4"
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@arm64-poc
     needs: lint-unit
     strategy:
       fail-fast: false
       matrix:
         include:
           - juju-channel: "3.4/stable"
-            command: "TEST_JUJU3=1 make functional"  # using TEST_JUJU3 due https://github.com/openstack-charmers/zaza/commit/af7eea953dd5d74d3d074fe67b5765dca3911ca6
+            command: "TEST_JUJU3=1 make functional"
+            runs-on: "['Ubuntu_ARM64_4C_16G_01']"
+            model-constraints: "arch=arm64"
+          - juju-channel: "3.4/stable"
+            command: "TEST_JUJU3=1 make functional"
+            runs-on: "['ubuntu-latest']"
+            model-constraints: ""
+
     with:
       command: ${{ matrix.command }}
       juju-channel: ${{ matrix.juju-channel }}
@@ -41,3 +48,5 @@ jobs:
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
+      runs-on: ${{ matrix.runs-on }}
+      model-constraints: ${{ matrix.model-constraints }}

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,9 @@ help:
 	@echo " make release - run clean, submodules and build targets"
 	@echo " make lint - run flake8 and black --check"
 	@echo " make black - run black and reformat files"
-	@echo " make proof - run charm proof"
 	@echo " make unittests - run the tests defined in the unittest subdirectory"
 	@echo " make functional - run the tests defined in the functional subdirectory"
-	@echo " make test - run lint, proof, unittests and functional targets"
+	@echo " make test - run lint, unittests and functional targets"
 	@echo ""
 
 clean:
@@ -49,22 +48,9 @@ build: clean submodules-update
 	@-git describe --always > ./version
 	@charmcraft -v pack ${BUILD_ARGS}
 	@bash -c ./rename.sh
-	@mkdir -p ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@unzip ${PROJECTPATH}/${CHARM_NAME}.charm -d ${CHARM_BUILD_DIR}/${CHARM_NAME}
 
-release: clean build unpack
+release: clean build
 	@echo "Charm is built at ${CHARM_BUILD_DIR}/${CHARM_NAME}"
-
-unpack: build
-	@-rm -rf ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@mkdir -p ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@echo "Unpacking built .charm into ${CHARM_BUILD_DIR}/${CHARM_NAME}"
-	@cd ${CHARM_BUILD_DIR}/${CHARM_NAME} && unzip -q ${CHARM_BUILD_DIR}/${CHARM_NAME}.charm
-	# until charmcraft copies READMEs in, we need to publish charms with readmes in them.
-	@cp ${PROJECTPATH}/README.md ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/copyright ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/repo-info ${CHARM_BUILD_DIR}/${CHARM_NAME}
-	@cp ${PROJECTPATH}/version ${CHARM_BUILD_DIR}/${CHARM_NAME}
 
 lint:
 	@echo "Running lint checks"
@@ -74,10 +60,6 @@ black:
 	@echo "Reformat files with black"
 	@tox -e black
 
-proof: unpack
-	@echo "Running charm proof"
-	@charm proof ${CHARM_BUILD_DIR}/${CHARM_NAME}
-
 unittests:
 	@echo "Running unit tests"
 	@tox -e unit
@@ -86,8 +68,8 @@ functional: build
 	@echo "Executing functional tests with ${PROJECTPATH}/${CHARM_NAME}.charm"
 	@CHARM_LOCATION=${PROJECTPATH} tox -e func -- ${FUNC_ARGS}
 
-test: lint proof unittests functional
+test: lint unittests functional
 	@echo "Tests completed for charm ${CHARM_NAME}."
 
 # The targets below don't depend on a file
-.PHONY: help submodules submodules-update clean build release lint black proof unittests functional test unpack snap
+.PHONY: help submodules submodules-update clean build release lint black unittests functional test snap

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,13 +6,17 @@ bases:
     - build-on:
         - name: ubuntu
           channel: "22.04"
-          architectures: ["amd64"]
+          architectures:
+              - amd64
+              - arm64
       run-on:
         - name: ubuntu
           channel: "22.04"
           architectures:
               - amd64
+              - arm64
         - name: ubuntu
           channel: "20.04"
           architectures:
               - amd64
+              - arm64

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   TEST_*
+  MODEL_*
 
 [testenv:build]
 deps = charmcraft<1.1.0


### PR DESCRIPTION
# (Don't merge) This is an example PR how to use arm64 runner on CI

* Remove un-used commands from Makefile
* Add arm64 runner to functional test
  * Need to add `arch=arm64` to `model-constraints`, which will used as environment variable `MODEL_CONSTRAINTS` for zaza. `model-constraints` now only supported by temporary branch *arm64-poc* on bootstack-action.