### PR TITLE
Rewrite lxd installation action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,8 +33,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Initialize lxd  # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
-        uses: canonical/setup-lxd@v0.1.1
+      # This should dropped once it's implemented on charming-actions itself. https://github.com/canonical/charming-actions/issues/140
+      - name: Install and configure lxd
+        run: |
+          set -x
+
+          # Sometimes runners can have lxd installed, usually the lts stable branch.
+          # Ensure we're always on the latest/stable release here.
+          if snap list lxd; then
+            sudo snap refresh lxd --channel=latest/stable
+          else
+            sudo snap install lxd --channel=latest/stable
+          fi
+
+          # Change the lxd daemon group from `lxd` to `adm`.
+          # Runner users are in the `adm` group, but not always the `lxd` group,
+          # so this ensures that the user can use lxc without sudo.
+          while [ -n "$(snap changes --abs-time lxd | awk '/^[0-9]+/ { if ($4 == "-") { print $4 } }')" ]; do
+            echo "waiting for in-progress changes to lxd snap..."
+            sleep 1
+          done
+          sudo snap set lxd daemon.group=adm
+
+          sudo lxd waitready
+          sudo lxd init --auto
+
+          # if docker is installed, fix firewall for lxd
+          sudo iptables -I DOCKER-USER -i lxdbr0 -j ACCEPT || true
+          sudo iptables -I DOCKER-USER -o lxdbr0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT || true
 
       - name: Pack and upload to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2


### PR DESCRIPTION
The setup-lxd action was [failing on the arm64 runner](https://github.com/canonical/charm-local-users/actions/runs/10240226493/job/28327824680),
at the iptables changes step.
This is because the arm64 runner did not have docker installed, but the action command failed if docker was not installed. https://github.com/canonical/setup-lxd/issues/19

As the setup-lxd action is listed as alpha state,
and the action is very small,
it seems fine to inline the commands here
so we can manage it ourselves to suit our use case better.

- ensure lxd latest/stable is installed
- switch the daemon group to adm (runner user on both machines is in this group)
- update iptables rules to work with docker (ignore errors if docker is not installed)

Differences between runner machines we need to handle:

`Ubuntu_ARM64_4C_16G_01` runner:
- lxd snap 5.0/stable is pre installed
- runner user is in the lxd group
- docker is not installed

`ubuntu-latest` runner:
- lxd is not installed
- runner user is not in the lxd group
- docker is installed