### PR TITLE
Pin charmcraft to v2

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -76,11 +76,6 @@ jobs:
           juju version
           juju controllers | grep Version -A 1 | awk '{print $9}'
 
-      - name: Show charmcraft information
-        run: |
-          snap list charmcraft
-          charmcraft --version
-
       - name: Run tests
         run: "make functional"
         env:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -75,6 +75,11 @@ jobs:
           juju version
           juju controllers | grep Version -A 1 | awk '{print $9}'
 
+      - name: Show charmcraft information
+        run: |
+          snap list charmcraft
+          charmcraft --version
+
       - name: Run tests
         run: "make functional"
         env:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -64,6 +64,7 @@ jobs:
         with:
           provider: "lxd"
           juju-channel: ${{ matrix.juju-channel }}
+          charmcraft-channel: "2.x/stable"
 
       - name: Install latest tox version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Pack and upload to charmhub
         uses: canonical/charming-actions/upload-charm@2.6.2
         with:
+          charmcraft-channel: "2.x/stable"
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           # Ensure the charm is built in an isolated environment and on the correct base in an lxd container.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,11 @@ Create and activate a virtualenv with the development requirements:
 
 ## Building
 
+This charm build config supports charmcraft v2.
+
 Run:
 
+    sudo snap install charmcraft --channel 2.x/stable --classic
     charmcraft pack
 
 ## Deploying local version


### PR DESCRIPTION
charmcraft.yaml still uses the v2 compatible bases, which charmcraft v3 does not support.
Pin charmcraft to v2 in the workflows until we migrate config to v3.

ref. https://github.com/canonical/charmcraft/issues/1783

Note: I'll port this to the automation repo once this is approved and tested.